### PR TITLE
Add extra Java options for MDM start.sh

### DIFF
--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -9,7 +9,7 @@ $JAVA_BIN \
 -Djasypt.encryptor.password={{encryptor_password}} \
 -Dlogging.config=./logback-spring.xml \
 {% if extra_java_options | length > 0 %}
-{{ extra_java_options | join(' ') }} \
+{{ extra_java_options | map('quote') | join(' ') }} \
 {% endif %}
 -jar ./mdm-server-{{app_version}}-SNAPSHOT.jar
 

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -6,8 +6,10 @@ JAVA_BIN={{ java_bin }}
 $JAVA_BIN -jar  \
 -Djasypt.encryptor.password={{encryptor_password}} \
 -Dlogging.config=./logback-spring.xml \
+# extra_java_options: optional list of additional JVM options to pass to the Java process.
+# Type: list of strings; Default: [] (no extra options).
 {% if extra_java_options | length > 0 %}
-{{ extra_java_options | join(' ') }} \
+{{ extra_java_options | map('quote') | join(' ') }} \
 {% endif %}
 ./mdm-server-{{app_version}}-SNAPSHOT.jar
 

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -3,8 +3,6 @@
 #JAVA_PATH=$(/usr/libexec/java_home -v 1.8)
 JAVA_BIN={{ java_bin }}
 
-$JAVA_BIN -jar  \
--Djasypt.encryptor.password={{encryptor_password}} \
 $JAVA_BIN \
 -Djasypt.encryptor.password={{encryptor_password}} \
 -Dlogging.config=./logback-spring.xml \

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -6,6 +6,8 @@ JAVA_BIN={{ java_bin }}
 $JAVA_BIN -jar  \
 -Djasypt.encryptor.password={{encryptor_password}} \
 -Dlogging.config=./logback-spring.xml \
+{% if extra_java_options | length > 0 %}
 {{ extra_java_options | join(' ') }} \
+{% endif %}
 ./mdm-server-{{app_version}}-SNAPSHOT.jar
 

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -5,11 +5,11 @@ JAVA_BIN={{ java_bin }}
 
 $JAVA_BIN -jar  \
 -Djasypt.encryptor.password={{encryptor_password}} \
+$JAVA_BIN \
+-Djasypt.encryptor.password={{encryptor_password}} \
 -Dlogging.config=./logback-spring.xml \
-# extra_java_options: optional list of additional JVM options to pass to the Java process.
-# Type: list of strings; Default: [] (no extra options).
 {% if extra_java_options | length > 0 %}
-{{ extra_java_options | map('quote') | join(' ') }} \
+{{ extra_java_options | join(' ') }} \
 {% endif %}
-./mdm-server-{{app_version}}-SNAPSHOT.jar
+-jar ./mdm-server-{{app_version}}-SNAPSHOT.jar
 

--- a/templates/start.sh.j2
+++ b/templates/start.sh.j2
@@ -6,5 +6,6 @@ JAVA_BIN={{ java_bin }}
 $JAVA_BIN -jar  \
 -Djasypt.encryptor.password={{encryptor_password}} \
 -Dlogging.config=./logback-spring.xml \
+{{ extra_java_options | join(' ') }} \
 ./mdm-server-{{app_version}}-SNAPSHOT.jar
 


### PR DESCRIPTION
This pull request updates the `start.sh.j2` template to allow passing additional Java options when starting the application. This makes it easier to customize the Java runtime configuration without modifying the script itself.

Enhancement to Java startup configuration:

* Added support for injecting extra Java options via the `extra_java_options` variable in the `start.sh.j2` template, improving flexibility for runtime configuration.